### PR TITLE
Screen Transition Unity Editor Fix

### DIFF
--- a/RWM-P2-TEAM-C/Packages/manifest.json
+++ b/RWM-P2-TEAM-C/Packages/manifest.json
@@ -15,7 +15,7 @@
     "com.unity.timeline": "1.2.18",
     "com.unity.ugui": "1.0.0",
     "ie.itcarlow.2dmovement": "https://github.com/itcgames/RWM-2DMovement.git?path=/2D%20Movement/Packages/ie.itcarlow.2dmovement#v3.2.0",
-    "ie.itcarlow.screentransitions": "https://github.com/itcgames/RWM-ScreenTransitions.git?path=/Packages/ie.itcarlow.screentransitions#v0.1.0",
+    "ie.itcarlow.screentransitions": "https://github.com/itcgames/RWM-ScreenTransitions.git?path=/Packages/ie.itcarlow.screentransitions#v0.1.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/RWM-P2-TEAM-C/Packages/packages-lock.json
+++ b/RWM-P2-TEAM-C/Packages/packages-lock.json
@@ -166,11 +166,11 @@
       "hash": "02c1e4e2680b55f561b839eefad597ec5ea57c3c"
     },
     "ie.itcarlow.screentransitions": {
-      "version": "https://github.com/itcgames/RWM-ScreenTransitions.git?path=/Packages/ie.itcarlow.screentransitions#v0.1.0",
+      "version": "https://github.com/itcgames/RWM-ScreenTransitions.git?path=/Packages/ie.itcarlow.screentransitions#v0.1.1",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "5a4624f2adccf743042fcdc7dcf6edc864e9952c"
+      "hash": "698436195a61891c6fa45d68eb80fc9c68dcac71"
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",


### PR DESCRIPTION
### What Changed
I have made a small change to my Screen Transition feature on my own Repo and pushed it up as Tag: V0.1.1.
This change does a check within the Editor file to see if the current setup allows for Unity Editor.
This will resolve the error during building.

### Please Look At
Both included files, please double check they target v0.1.1 instead of v0.1.0.