### PR TITLE
Multiple Transition Points

### DIFF
--- a/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
+++ b/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
@@ -121,6 +121,51 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &936331642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 936331644}
+  - component: {fileID: 936331643}
+  m_Layer: 0
+  m_Name: Zone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &936331643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 936331642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2eaf8577c32aec468f09bcd72fdf3ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  transitionPoint: 0
+  type: 0
+--- !u!4 &936331644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 936331642}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.683744, y: 0.06750083, z: -1.410486}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2010743309
 GameObject:
   m_ObjectHideFlags: 0

--- a/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
+++ b/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
@@ -220,7 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cam: {fileID: 0}
   type: 0
-  transitionPoint: {x: 3, y: 0}
+  transitionPoint: {x: 0, y: 0}
 --- !u!114 &2010743314
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -234,6 +234,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mainCam: {fileID: 0}
-  transitionPoint: {x: 0, y: 0}
+  transitionPoints: []
   speed: 0.1
   m_moving: 0

--- a/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
+++ b/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
@@ -419,7 +419,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2eaf8577c32aec468f09bcd72fdf3ba, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  transitionPoint: 0
+  pointOne: 0
+  pointTwo: 1
   type: 0
 --- !u!4 &936331644
 Transform:

--- a/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
+++ b/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
@@ -121,6 +121,274 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &247898839
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 247898845}
+  - component: {fileID: 247898844}
+  - component: {fileID: 247898843}
+  - component: {fileID: 247898842}
+  - component: {fileID: 247898841}
+  - component: {fileID: 247898840}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!50 &247898840
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247898839}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0
+  m_GravityScale: 6
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!114 &247898841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247898839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65acb87fefd0f8042a3f8602ebf90a79, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!95 &247898842
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247898839}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: a7791ad96a917d045b668deab68c5949, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!212 &247898843
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247898839}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 8020143640844766479, guid: 158cc7ffc66fe014fbf16c32faf9fc58,
+    type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.16}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &247898844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247898839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 434c82429ec95684889105cf450b2b69, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _walkableSurfaceTagName: Ground
+  leftKey: 97
+  rightKey: 100
+  jumpKey: 32
+  impluseJumpVel: 6
+  TimeToReachMaxHeight: 0.5
+  _movementTime: 0.2
+  _MAX_WALKING_SPEED: 10
+  acclearation: 17
+  _LOWEST_WALKING_SPEED: 2
+--- !u!4 &247898845
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 247898839}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 12, y: 12, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &889430537
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 889430540}
+  - component: {fileID: 889430539}
+  - component: {fileID: 889430538}
+  m_Layer: 0
+  m_Name: New Sprite
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &889430538
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889430537}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0.049999997, y: 0.049999997, z: 0.049999997, w: 0.049999997}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.16, y: 0.16}
+    newSize: {x: 0.16, y: 0.16}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.16, y: 0.16}
+  m_EdgeRadius: 0
+--- !u!212 &889430539
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889430537}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.16}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &889430540
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889430537}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -3.14, z: 0}
+  m_LocalScale: {x: 204.91, y: 12.83, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &936331642
 GameObject:
   m_ObjectHideFlags: 0
@@ -131,6 +399,7 @@ GameObject:
   m_Component:
   - component: {fileID: 936331644}
   - component: {fileID: 936331643}
+  - component: {fileID: 936331645}
   m_Layer: 0
   m_Name: Zone
   m_TagString: Untagged
@@ -160,12 +429,38 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 936331642}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.683744, y: 0.06750083, z: -1.410486}
+  m_LocalPosition: {x: 5, y: -0.09, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &936331645
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 936331642}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 5}
+  m_EdgeRadius: 0
 --- !u!1 &2010743309
 GameObject:
   m_ObjectHideFlags: 0
@@ -265,7 +560,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cam: {fileID: 0}
   type: 0
-  transitionPoint: {x: 0, y: 0}
+  transitionPoint: {x: 10, y: 0}
 --- !u!114 &2010743314
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -279,6 +574,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mainCam: {fileID: 0}
-  transitionPoints: []
+  transitionPoints:
+  - {x: 10, y: 0}
+  - {x: 0, y: 0}
   speed: 0.1
   m_moving: 0

--- a/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
+++ b/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity
@@ -1,0 +1,239 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &2010743309
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2010743312}
+  - component: {fileID: 2010743311}
+  - component: {fileID: 2010743310}
+  - component: {fileID: 2010743314}
+  - component: {fileID: 2010743313}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2010743310
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010743309}
+  m_Enabled: 1
+--- !u!20 &2010743311
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010743309}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2010743312
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010743309}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2010743313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010743309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fd17ebb69c343c4a9d130a49d2eac15, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 0}
+  type: 0
+  transitionPoint: {x: 3, y: 0}
+--- !u!114 &2010743314
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2010743309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62d90d7de2d210a4f91014c082366067, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainCam: {fileID: 0}
+  transitionPoint: {x: 0, y: 0}
+  speed: 0.1
+  m_moving: 0

--- a/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity.meta
+++ b/RWM-P2-TEAM-C/Assets/Scenes/CameraTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 14411ea5c258afa488afef7b2e76bf5d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RWM-P2-TEAM-C/Assets/Scripts/CameraMover.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/CameraMover.cs
@@ -5,10 +5,11 @@ using UnityEngine;
 public class CameraMover : MonoBehaviour
 {
     public Camera mainCam;
-    public Vector2 transitionPoint;
+    public List<Vector2> transitionPoints;
     public float speed = 0.1f;
     public bool m_moving;
 
+    private Vector2 chosenPoint;
     private List<Behaviour> heldComponents;
 
     void Start()
@@ -16,11 +17,14 @@ public class CameraMover : MonoBehaviour
         mainCam = Camera.main;
     }
 
-    public void StartMovement()
+    public void AddPoint(Vector2 t_point)
     {
-        
-        transitionPoint = GetComponent<ScreenTransition>().transitionPoint;
+        transitionPoints.Add(t_point);
+    }
 
+    public void StartMovement(int point, ScreenTransition.transitionTypes t_type)
+    {
+        chosenPoint = transitionPoints[point];
         foreach (Behaviour behaviour in GetComponents<Behaviour>())
         {
             if(behaviour.enabled)
@@ -48,18 +52,18 @@ public class CameraMover : MonoBehaviour
             wentThroughMove = true;
             if (GetComponent<ScreenTransition>().type == ScreenTransition.transitionTypes.HORIZONTAL)
             {
-                if (mainCam.transform.position.x < transitionPoint.x)
+                if (mainCam.transform.position.x < chosenPoint.x)
                 {
-                    while (mainCam.transform.position.x <= transitionPoint.x)
+                    while (mainCam.transform.position.x <= chosenPoint.x)
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x + speed, mainCam.transform.position.y, mainCam.transform.position.z);
 
                         yield return new WaitForSeconds(0.1f);
                     }
                 }
-                else if (mainCam.transform.position.x > transitionPoint.x)
+                else if (mainCam.transform.position.x > chosenPoint.x)
                 {
-                    while (mainCam.transform.position.x >= transitionPoint.x)
+                    while (mainCam.transform.position.x >= chosenPoint.x)
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x - speed, mainCam.transform.position.y, mainCam.transform.position.z);
 
@@ -67,20 +71,20 @@ public class CameraMover : MonoBehaviour
                     }
                 }
             }
-            if (GetComponent<ScreenTransition>().type == ScreenTransition.transitionTypes.HORIZONTAL)
+            if (GetComponent<ScreenTransition>().type == ScreenTransition.transitionTypes.VERTICAL)
             {
-                if (mainCam.transform.position.y < transitionPoint.y)
+                if (mainCam.transform.position.y < chosenPoint.y)
                 {
-                    while (mainCam.transform.position.y <= transitionPoint.y)
+                    while (mainCam.transform.position.y <= chosenPoint.y)
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x, mainCam.transform.position.y + speed, mainCam.transform.position.z);
 
                         yield return new WaitForSeconds(0.1f);
                     }
                 }
-                else if (mainCam.transform.position.y > transitionPoint.y)
+                else if (mainCam.transform.position.y > chosenPoint.y)
                 {
-                    while (mainCam.transform.position.y >= transitionPoint.y)
+                    while (mainCam.transform.position.y >= chosenPoint.y)
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x, mainCam.transform.position.y - speed, mainCam.transform.position.z);
 

--- a/RWM-P2-TEAM-C/Assets/Scripts/CameraMover.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/CameraMover.cs
@@ -22,6 +22,12 @@ public class CameraMover : MonoBehaviour
         transitionPoints.Add(t_point);
     }
 
+    public void RemoveLastPoint()
+    {
+        if(transitionPoints.Count > 0) // make sure points exist first
+            transitionPoints.RemoveAt(transitionPoints.Count - 1); // removes the last item in the list
+    }
+
     public void StartMovement(int point, ScreenTransition.transitionTypes t_type)
     {
         chosenPoint = transitionPoints[point];

--- a/RWM-P2-TEAM-C/Assets/Scripts/CameraMover.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/CameraMover.cs
@@ -51,11 +51,9 @@ public class CameraMover : MonoBehaviour
 
     IEnumerator movement()
     {
-        bool wentThroughMove = false;
         if(!m_moving)
         { // only do this enumerator if it isn't already happening, to stop overlapping
             m_moving = true;
-            wentThroughMove = true;
             if (GetComponent<ScreenTransition>().type == ScreenTransition.transitionTypes.HORIZONTAL)
             {
                 if (mainCam.transform.position.x < chosenPoint.x)
@@ -64,7 +62,7 @@ public class CameraMover : MonoBehaviour
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x + speed, mainCam.transform.position.y, mainCam.transform.position.z);
 
-                        yield return new WaitForSeconds(0.1f);
+                        yield return new WaitForSeconds(0.025f);
                     }
                 }
                 else if (mainCam.transform.position.x > chosenPoint.x)
@@ -73,7 +71,7 @@ public class CameraMover : MonoBehaviour
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x - speed, mainCam.transform.position.y, mainCam.transform.position.z);
 
-                        yield return new WaitForSeconds(0.1f);
+                        yield return new WaitForSeconds(0.025f);
                     }
                 }
             }
@@ -85,7 +83,7 @@ public class CameraMover : MonoBehaviour
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x, mainCam.transform.position.y + speed, mainCam.transform.position.z);
 
-                        yield return new WaitForSeconds(0.1f);
+                        yield return new WaitForSeconds(0.025f);
                     }
                 }
                 else if (mainCam.transform.position.y > chosenPoint.y)
@@ -94,11 +92,10 @@ public class CameraMover : MonoBehaviour
                     {
                         mainCam.transform.position = new Vector3(mainCam.transform.position.x, mainCam.transform.position.y - speed, mainCam.transform.position.z);
 
-                        yield return new WaitForSeconds(0.1f);
+                        yield return new WaitForSeconds(0.025f);
                     }
                 }
             }
-            Debug.Log("camera reached end");
         }
 
         // now that the mover is done, re-enable any disabled components
@@ -114,6 +111,7 @@ public class CameraMover : MonoBehaviour
             }
         }
 
+        m_moving = false;
         yield break;
     }
 }

--- a/RWM-P2-TEAM-C/Assets/Scripts/TempInput.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TempInput.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class TempInput : MonoBehaviour
 {
+    public int transitionPoint;
+    public ScreenTransition.transitionTypes type;
     // Start is called before the first frame update
     void Start()
     {
@@ -15,7 +17,7 @@ public class TempInput : MonoBehaviour
     {
         if (col.tag == "Player")
         {
-            Camera.main.GetComponent<CameraMover>().StartMovement();
+            Camera.main.GetComponent<CameraMover>().StartMovement(transitionPoint, type);
         }
     }
 }

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if UNITY_EDITOR
+using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
@@ -34,3 +35,4 @@ public class TransitionEditor : Editor
 		base.OnInspectorGUI();
 	}
 }
+#endif

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+
+[CustomEditor(typeof(CameraMover))]
+public class TransitionEditor : Editor
+{
+	private CameraMover cM;
+	private ScreenTransition sT;
+	private Camera mainCam;
+
+	private void OnEnable()
+	{
+		// Method 1
+		cM = (CameraMover) target;
+		mainCam = Camera.main;
+		sT = mainCam.GetComponent<ScreenTransition>();
+	}
+
+	public override void OnInspectorGUI()
+	{
+		if (GUILayout.Button("Add Point"))
+		{
+			cM.AddPoint(sT.transitionPoint);
+		}
+
+		// Draw default inspector after button...
+		base.OnInspectorGUI();
+	}
+}

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs
@@ -25,6 +25,11 @@ public class TransitionEditor : Editor
 			cM.AddPoint(sT.transitionPoint);
 		}
 
+		if (GUILayout.Button("Remove Last Point"))
+		{
+			cM.RemoveLastPoint();
+		}
+
 		// Draw default inspector after button...
 		base.OnInspectorGUI();
 	}

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs.meta
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 518f74858f934d24ca1caab1dd55ca32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
@@ -4,15 +4,29 @@ using UnityEngine;
 
 public class TransitionZone : MonoBehaviour
 {
-    public int transitionPoint;
+    public int pointOne;
+    public int pointTwo;
     public ScreenTransition.transitionTypes type;
+    bool swap = false;
 
     // begin transition on collision with player only
     void OnTriggerEnter2D(Collider2D col)
     {
         if (col.tag == "Player")
         {
-            Camera.main.GetComponent<CameraMover>().StartMovement(transitionPoint, type);
+            if(!Camera.main.GetComponent<CameraMover>().m_moving)
+            {
+                if (!swap)
+                {
+                    Camera.main.GetComponent<CameraMover>().StartMovement(pointOne, type);
+                    swap = true;
+                }
+                else
+                {
+                    Camera.main.GetComponent<CameraMover>().StartMovement(pointTwo, type);
+                    swap = false;
+                }
+            }   
         }
     }
 }

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
@@ -7,15 +7,7 @@ public class TransitionZone : MonoBehaviour
     public int transitionPoint;
     public ScreenTransition.transitionTypes type;
 
-    void Update()
-    {
-        if(Input.GetKeyDown("space"))
-        {
-            Camera.main.GetComponent<CameraMover>().StartMovement(transitionPoint, type);
-        }
-    }
-
-    // when the GameObjects collider arrange for this GameObject to travel to the left of the screen
+    // begin transition on collision with player only
     void OnTriggerEnter2D(Collider2D col)
     {
         if (col.tag == "Player")

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
@@ -19,13 +19,13 @@ public class TransitionZone : MonoBehaviour
                 if (!swap)
                 {
                     Camera.main.GetComponent<CameraMover>().StartMovement(pointOne, type);
-                    swap = true;
                 }
                 else
                 {
                     Camera.main.GetComponent<CameraMover>().StartMovement(pointTwo, type);
-                    swap = false;
                 }
+
+                swap = !swap;
             }   
         }
     }

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TransitionZone : MonoBehaviour
+{
+    public int transitionPoint;
+    public ScreenTransition.transitionTypes type;
+
+    void Update()
+    {
+        if(Input.GetKeyDown("space"))
+        {
+            Camera.main.GetComponent<CameraMover>().StartMovement(transitionPoint, type);
+        }
+    }
+
+    // when the GameObjects collider arrange for this GameObject to travel to the left of the screen
+    void OnTriggerEnter2D(Collider2D col)
+    {
+        if (col.tag == "Player")
+        {
+            Camera.main.GetComponent<CameraMover>().StartMovement(transitionPoint, type);
+        }
+    }
+}

--- a/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs.meta
+++ b/RWM-P2-TEAM-C/Assets/Scripts/TransitionZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2eaf8577c32aec468f09bcd72fdf3ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
+++ b/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
@@ -92,8 +92,6 @@ namespace Tests
 
         }
 
-
-
         private void setupCamera()
         {
             mainCam = Camera.main;

--- a/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
+++ b/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
@@ -50,6 +50,32 @@ namespace Tests
 
         }
 
+        [UnityTest]
+        public IEnumerator AddingPoints()
+        {
+            setupCamera();
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(1.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(2.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(3.0f, 0.0f));
+            yield return new WaitForSeconds(0.1f);
+
+            Assert.AreEqual(3, mainCam.GetComponent<CameraMover>().transitionPoints.Count);
+
+        }
+
+        [UnityTest]
+        public IEnumerator RemovingLastAddedPoint()
+        {
+            setupCamera();
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(1.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(2.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().RemoveLastPoint();
+            yield return new WaitForSeconds(0.1f);
+
+            Assert.AreEqual(1, mainCam.GetComponent<CameraMover>().transitionPoints.Count);
+
+        }
+
 
 
         private void setupCamera()

--- a/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
+++ b/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
@@ -28,7 +28,7 @@ namespace Tests
         {
             setupCamera();
             Vector3 pos = mainCam.transform.position;
-            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(1.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(100.0f, 0.0f));
             mainCam.GetComponent<CameraMover>().StartMovement(0, ScreenTransition.transitionTypes.HORIZONTAL);
 
             yield return new WaitForSeconds(0.1f);
@@ -46,7 +46,7 @@ namespace Tests
 
             yield return new WaitForSeconds(0.5f);
 
-            Assert.AreEqual(true, mainCam.GetComponent<CameraMover>().m_moving);
+            Assert.AreEqual(false, mainCam.GetComponent<CameraMover>().m_moving);
 
         }
 
@@ -81,6 +81,9 @@ namespace Tests
         private void setupCamera()
         {
             mainCam = Camera.main;
+
+            // remove any other points that may exist on the camera for our tests
+            mainCam.GetComponent<CameraMover>().transitionPoints.Clear();
         }
     }
 }

--- a/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
+++ b/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
@@ -76,6 +76,22 @@ namespace Tests
 
         }
 
+        [UnityTest]
+        public IEnumerator MovesToCorrectPoint()
+        {
+            setupCamera();
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(1.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(1000.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().StartMovement(0, ScreenTransition.transitionTypes.HORIZONTAL);
+
+            yield return new WaitForSeconds(0.5f);
+
+            Assert.Less(mainCam.transform.position.x, mainCam.GetComponent<CameraMover>().transitionPoints[1].x);
+            Assert.Less(mainCam.transform.position.x, mainCam.GetComponent<CameraMover>().transitionPoints[1].x + 0.1f);
+            Assert.GreaterOrEqual(mainCam.transform.position.x, mainCam.GetComponent<CameraMover>().transitionPoints[0].x);
+
+        }
+
 
 
         private void setupCamera()

--- a/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
+++ b/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
@@ -14,13 +14,13 @@ namespace Tests
         [SetUp]
         public void Setup()
         {
-            SceneManager.LoadScene("Game", LoadSceneMode.Single);
+            SceneManager.LoadScene("CameraTestScene", LoadSceneMode.Single);
         }
 
         [TearDown]
         public void Teardown()
         {
-            SceneManager.UnloadSceneAsync("Game");
+            SceneManager.UnloadSceneAsync("CameraTestScene");
         }
 
         [UnityTest]

--- a/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
+++ b/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
@@ -90,7 +90,7 @@ namespace Tests
             Assert.Less(mainCam.transform.position.x, mainCam.GetComponent<CameraMover>().transitionPoints[1].x + 0.1f);
             Assert.GreaterOrEqual(mainCam.transform.position.x, mainCam.GetComponent<CameraMover>().transitionPoints[0].x);
 
-        }
+        } 
 
         private void setupCamera()
         {

--- a/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
+++ b/RWM-P2-TEAM-C/Assets/Tests/ScreenTransitionTests.cs
@@ -28,7 +28,8 @@ namespace Tests
         {
             setupCamera();
             Vector3 pos = mainCam.transform.position;
-            mainCam.GetComponent<CameraMover>().StartMovement();
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(1.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().StartMovement(0, ScreenTransition.transitionTypes.HORIZONTAL);
 
             yield return new WaitForSeconds(0.1f);
 
@@ -40,11 +41,10 @@ namespace Tests
         public IEnumerator TransitionEnds()
         {
             setupCamera();
-            Vector3 pos = mainCam.transform.position;
-            mainCam.GetComponent<ScreenTransition>().transitionPoint = new Vector2(1.0f, 0.0f);
-            mainCam.GetComponent<CameraMover>().StartMovement();
+            mainCam.GetComponent<CameraMover>().AddPoint(new Vector2(1.0f, 0.0f));
+            mainCam.GetComponent<CameraMover>().StartMovement(0, ScreenTransition.transitionTypes.HORIZONTAL);
 
-            yield return new WaitForSeconds(1.5f);
+            yield return new WaitForSeconds(0.5f);
 
             Assert.AreEqual(true, mainCam.GetComponent<CameraMover>().m_moving);
 

--- a/RWM-P2-TEAM-C/ProjectSettings/EditorBuildSettings.asset
+++ b/RWM-P2-TEAM-C/ProjectSettings/EditorBuildSettings.asset
@@ -11,4 +11,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/PlayerTestScene.unity
     guid: 7ca3673c25a388e40a7b4e63568b9f53
+  - enabled: 1
+    path: Assets/Scenes/CameraTestScene.unity
+    guid: 14411ea5c258afa488afef7b2e76bf5d
   m_configObjects: {}


### PR DESCRIPTION
### What Changed
The Camera Mover can now add Transition Points to itself, storing them for later use.
Transition Zones exist now, and define the Transition Type and what points it uses.
Transition Zones can hold onto two Transition Points, using the Transition Type to say what way the Camera should move between both points.

### Please look at
The overall implementation, try to add a new Transition Zone and some new Transition Points in the Inspector, and see if the camera moves when the Player enters the Transition Zone trigger.